### PR TITLE
Added support for dynamic compatibility version

### DIFF
--- a/roles/datacenter/defaults/main.yml
+++ b/roles/datacenter/defaults/main.yml
@@ -8,6 +8,7 @@ admin_password: changeme
 
 dc_name: Default
 cluster_name: Default
+compatibility_version: 3.6
 cpu_type: Intel Nehalem Family
 mac_address_range: ''
 mac_pool_name: ''

--- a/roles/datacenter/files/datacenter_config
+++ b/roles/datacenter/files/datacenter_config
@@ -5,8 +5,6 @@ from ovirtsdk.api import API
 from ovirtsdk.xml import params
 from ovirtsdk.infrastructure.errors import RequestError
 
-VERSION = params.Version(major='3', minor='6')
-
 
 def main():
     args = parse_args()
@@ -16,9 +14,10 @@ def main():
         password=args.password,
         insecure=True
     )
-
+    major, minor = args.comp_version.split('.')
+    version = params.Version(major=major, minor=minor)
     print "Creating DataCenter"
-    datacenter = create_datacenter(engine_api, args.dc_name)
+    datacenter = create_datacenter(engine_api, args.dc_name, version)
     if args.mac_address_range and args.mac_pool_name:
         print('Creating mac address pool')
         mac_pool = create_mac_pool(
@@ -28,7 +27,8 @@ def main():
         )
         assign_mac_pool(datacenter, mac_pool)
     print("Creating Cluster")
-    create_cluster(engine_api, datacenter, args.cluster_name, args.cpu_type)
+    create_cluster(engine_api, datacenter, args.cluster_name,
+                   args.cpu_type, version)
 
 
 def parse_args():
@@ -38,19 +38,23 @@ def parse_args():
     parser.add_option('--url', dest='url',
                       help='the url for the Engine api')
     parser.add_option('--username', dest='username',
-                      help='the username for the Engine api')
+                      help='the username for the Engine api',
+                      default='admin@internal')
     parser.add_option('--password', dest='password',
                       help='the password for the Engine api')
     parser.add_option('--name', dest='dc_name',
-                      help='the name of the datacenter')
+                      help='the name of the datacenter', default='Default')
     parser.add_option('--cluster-name', dest='cluster_name',
-                      help='the name of the cluster')
+                      help='the name of the cluster', default='Default')
     parser.add_option('--cpu-type', dest='cpu_type',
-                      help='the cpu type for the cluster')
+                      help='the cpu type for the cluster',
+                      default='Intel Nehalem Family')
     parser.add_option('--mac-address-range', dest='mac_address_range',
                       help='a mac address range in the form start,end')
     parser.add_option('--mac-pool-name', dest='mac_pool_name',
                       help='the name of a custom mac address pool')
+    parser.add_option('--comp-version', dest='comp_version',
+                      help='the compatibility version', default='3.6')
     (options, args) = parser.parse_args()
 
     if not all(options.__dict__.values()):
@@ -79,11 +83,11 @@ def get_api(url=None, user=None, password=None, insecure=False, timeout=30):
             time.sleep(10)
 
 
-def create_datacenter(engine_api, name):
+def create_datacenter(engine_api, name, version):
     dc_params = params.DataCenter(
         name=name,
         storage_type='nfs',
-        version=VERSION
+        version=version
     )
     try:
         return (engine_api.datacenters.get(name=name) or
@@ -131,13 +135,13 @@ def assign_mac_pool(datacenter, pool):
         exit(1)
 
 
-def create_cluster(engine_api, datacenter, cluster_name, cpu_type):
+def create_cluster(engine_api, datacenter, cluster_name, cpu_type, version):
     cpu_params = params.CPU(id=cpu_type)
     cluster_params = params.Cluster(
         name=cluster_name,
         cpu=cpu_params,
         data_center=datacenter,
-        version=VERSION
+        version=version
     )
     try:
         cluster = engine_api.clusters.get(name=cluster_name)

--- a/roles/datacenter/tasks/main.yml
+++ b/roles/datacenter/tasks/main.yml
@@ -27,6 +27,7 @@
                                           --cpu-type='{{ cpu_type }}'
                                           --mac-address-range='{{ mac_address_range }}'
                                           --mac-pool-name='{{ mac_pool_name }}'
+                                          --comp-version='{{ compatibility_version }}'
   retries: 5
   delay: 60
   tags:


### PR DESCRIPTION
To be able to add datacenter and cluster of different compatibility
versions, we should have the option to choose dynamically compatibility
version from ansible vars.