### PR TITLE
Restart imageio-daemon on all hypervisors in self-hosted RHV deploy

### DIFF
--- a/roles/self_hosted_additional_host/tasks/main.yml
+++ b/roles/self_hosted_additional_host/tasks/main.yml
@@ -43,3 +43,8 @@
   poll: 5
   tags:
     - install
+
+- name: Restart imageio-daemon
+  service:
+    name: ovirt-imageio-daemon
+    state: restarted


### PR DESCRIPTION
I've found that after running `hosted-engine --deploy` on a hypervisor, disk-image uploads repeatedly fail until `ovirt-imageio-daemon.service` is restarted.  

Previously, we were under the impression that only the hypervisor hosting the engine needed the imageio daemon to be restarted, but today I had several disk images fail to upload to the second hypervisor in a cluster.

This is a workaround for: [BZ 1411491](https://bugzilla.redhat.com/show_bug.cgi?id=1411491)

Spoke with @fabianvf about this fix, marking with "DO NOT MERGE" for now, until I test more extensively.