### PR TITLE
[Needs testing] 1413926 - Turn off SSH service until cloud-init is done

### DIFF
--- a/roles/launch_vms/tasks/main.yml
+++ b/roles/launch_vms/tasks/main.yml
@@ -110,8 +110,13 @@
       dns_servers: '{{ nameservers if nameservers is defined else None }}'
       authorized_ssh_keys: '{{ ssh_key }}'
       custom_script: |
+        bootcmd:
+          - [ 'cloud-init-per', 'once', 'systemctl', 'disable', 'sshd' ]
+          - [ 'cloud-init-per', 'once', 'systemctl', 'stop', 'sshd' ]
         runcmd:
           - [ 'systemctl', 'restart', 'network']
+          - [ 'systemctl', 'enable', 'sshd' ]
+          - [ 'systemctl', 'start', 'sshd' ]
 
   register: vm_start_jobs
   async: 3600


### PR DESCRIPTION
On some machines, port 22 comes up before SSH is ready to accept connections after running cloud-init. This PR aims to alleviate this issue by starting up SSH only after all other cloud-init tasks have been completed. 