### PR TITLE
Remove ansible warning from self_hosted playbook

### DIFF
--- a/roles/satellite_registration/tasks/main.yml
+++ b/roles/satellite_registration/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: Get certificate from Satellite
-  yum: name=http://{{ satellite_fqdn }}/pub/katello-ca-consumer-latest.noarch.rpm state=present
+  yum:
+    name: http://{{ satellite_fqdn }}/pub/katello-ca-consumer-latest.noarch.rpm
+    state: present
 
 - name: Register to Satellite
   redhat_subscription:

--- a/roles/self_hosted_first_host/tasks/main.yml
+++ b/roles/self_hosted_first_host/tasks/main.yml
@@ -60,7 +60,7 @@
 
   - name: Set authorized ssh key if not provided
     set_fact: ssh_authorized_keys={{ hypervisor_authorized_keys.stdout_lines }}
-  when: '{{ ssh_authorized_keys == [] }}'
+  when: ssh_authorized_keys == []
 
 - name: create config directory
   file:
@@ -131,7 +131,7 @@
     hosted-engine --deploy --config-append={{ config_dir }}/answers
   async: 12000
   poll: 5
-  when: '{{ installed.rc > 0 }}'
+  when: installed.rc > 0
   tags:
     - install
 

--- a/self_hosted.yml
+++ b/self_hosted.yml
@@ -6,7 +6,7 @@
   roles:
     - wait_for_host_up
     - override_tty
-    - { role: subscription, when: '{{ repositories|length > 0 }}'}
+    - { role: subscription, when: repositories|length > 0 }
     - wait_for_yum_lock
     - self_hosted_first_host
 
@@ -15,12 +15,12 @@
   gather_facts: no
   roles:
     - wait_for_host_up
-    - { role: satellite_registration, when: '{{ register_to_satellite is defined and register_to_satellite }}'}
-    - { role: subscription, when: '{{ repositories|length > 0 }}'}
+    - { role: satellite_registration, when: register_to_satellite is defined and register_to_satellite }
+    - { role: subscription, when: repositories|length > 0 }
     - { role: wait_for_engine, tags: ['config'] }
     - datacenter
     - storage
-    - { role: self_hosted_engine, when: '{{ repositories|length > 0 }}'}
+    - { role: self_hosted_engine, when: repositories|length > 0 }
     - wait_for_active_he_vm
 
 - hosts: self_hosted_additional_hosts
@@ -31,7 +31,7 @@
   roles:
     - wait_for_host_up
     - override_tty
-    - { role: subscription, when: '{{ repositories|length > 0 }}'}
+    - { role: subscription, when: repositories|length > 0 }
     - wait_for_yum_lock
-    - { role: self_hosted_additional_host, when: '{{ ovirt_engine_version < 4.1 }}' }
-    - { role: register_hypervisor, deploy_hosted_engine: True, when: '{{ ovirt_engine_version >= 4.1 }}' }
+    - { role: self_hosted_additional_host, when: ovirt_engine_version < 4.1 }
+    - { role: register_hypervisor, deploy_hosted_engine: True, when: ovirt_engine_version >= 4.1 }


### PR DESCRIPTION
for example:
15:58:13 TASK [subscription : print repositories] ***************************************
15:58:13  [WARNING]: when statements should not include jinja2 templating delimiters
15:58:13 such as {{ }} or {% %}. Found: {{ repositories|length > 0 }}
15:58:13 skipping: [puma24.scl.lab.tlv.redhat.com]
15:58:13 
15:58:13 TASK [subscription : disable all] **********************************************
15:58:13  [WARNING]: when statements should not include jinja2 templating delimiters
15:58:13 such as {{ }} or {% %}. Found: {{ repositories|length > 0 }}
15:58:13 skipping: [puma24.scl.lab.tlv.redhat.com]
15:58:13 
15:58:13 TASK [subscription : enable repos] *********************************************
15:58:13  [WARNING]: when statements should not include jinja2 templating delimiters
15:58:13 such as {{ }} or {% %}. Found: {{ repositories|length > 0 }}
15:58:13 skipping: [puma24.scl.lab.tlv.redhat.com]

after this patch:
17:16:51 TASK [subscription : print repositories] ***************************************
17:16:51 skipping: [puma23.scl.lab.tlv.redhat.com]
17:16:51 
17:16:51 TASK [subscription : disable all] **********************************************
17:16:51 skipping: [puma23.scl.lab.tlv.redhat.com]
17:16:51 
17:16:51 TASK [subscription : enable repos] *********************************************
17:16:51 skipping: [puma23.scl.lab.tlv.redhat.com]
