### PR TITLE
Fix the storage type to support fcp and glusterfs

### DIFF
--- a/roles/self_hosted_first_host/defaults/main.yml
+++ b/roles/self_hosted_first_host/defaults/main.yml
@@ -10,7 +10,7 @@ interface_name: '{{ ansible_default_ipv4.interface }}'
 cluster_name: Default
 storage_datacenter_name: hosted_storage
 hosted_storage_type: nfs
-storage_domain_type: "{{ 'nfs3' if hosted_storage_type == 'nfs' else 'glusterfs' if hosted_storage_type == 'gluster' else hosted_storage_type }}"
+storage_domain_type: "{{ 'nfs3' if hosted_storage_type == 'nfs' else 'glusterfs' if hosted_storage_type == 'gluster' else 'fc' if hosted_storage_type == 'fcp' else hosted_storage_type }}"
 hosted_storage_name: my_hosted_storage
 hosted_storage_address: localhost
 hosted_storage_path: /path/to/storage

--- a/roles/self_hosted_first_host/templates/answers.j2
+++ b/roles/self_hosted_first_host/templates/answers.j2
@@ -13,7 +13,7 @@ OVEHOSTED_ENGINE/insecureSSL=none:None
 OVEHOSTED_ENGINE/clusterName=str:Default
 OVEHOSTED_STORAGE/storageDatacenterName=str:{{ storage_datacenter_name }}
 OVEHOSTED_STORAGE/domainType=str:{{ storage_domain_type }}
-{% if hosted_storage_type in ('iscsi', 'fc') %}
+{% if hosted_storage_type in ('iscsi', 'fcp', 'fc') %}
 OVEHOSTED_STORAGE/LunID=str:{{ hosted_storage_lun }}
 {% else %}
 OVEHOSTED_STORAGE/storageDomainConnection=str:{{ hosted_storage_address }}:{{ hosted_storage_path }}
@@ -25,7 +25,7 @@ OVEHOSTED_STORAGE/iSCSIPortalUser=none:None
 OVEHOSTED_STORAGE/iSCSIPortal=none:None
 OVEHOSTED_STORAGE/iSCSITargetName=none:None
 {% endif %}
-{% if hosted_storage_type == 'gluster' %}
+{% if hosted_storage_type in ('glusterfs', 'gluster') %}
 OVEHOSTED_STORAGE/glusterProvisionedShareName=str:{{ hosted_storage_name }}
 OVEHOSTED_STORAGE/glusterProvisioningEnabled=bool:False
 OVEHOSTED_STORAGE/glusterBrick=none:None

--- a/roles/self_hosted_first_host/templates/user-data.j2
+++ b/roles/self_hosted_first_host/templates/user-data.j2
@@ -30,7 +30,7 @@ write_files:
      OVESETUP_DB/port=int:{{ ovirt_engine_db_port }}
      OVESETUP_DB/database=str:{{ ovirt_engine_db_name }}
      OVESETUP_CONFIG/applicationMode=str:{{ engine_application_mode }}
-     OVESETUP_CONFIG/storageType=str:{{ hosted_storage_type }}
+     OVESETUP_CONFIG/storageType=str:{% if hosted_storage_type == 'fcp' %}fc{% elif hosted_storage_type == 'glusterfs' %}gluster{% else %}{{ hosted_storage_type }}{% endif %}{{ '' }}
      OVESETUP_DWH_CORE/enable=bool:True
      OVESETUP_DWH_CONFIG/scale=str:1
      OVESETUP_DWH_CONFIG/dwhDbBackupDir=str:/var/lib/ovirt-engine-dwh/backups


### PR DESCRIPTION
since the engine return fcp and glusterfs so it's better to use it like that.
also keep the ansible templates to support the regular names (gluster, fc) too.