### PR TITLE
Revert "Add support of force ipv4 or ipv6"

### DIFF
--- a/roles/self_hosted_first_host/templates/answers.j2
+++ b/roles/self_hosted_first_host/templates/answers.j2
@@ -9,12 +9,6 @@ OVEHOSTED_NETWORK/fqdn=str:{{ engine_fqdn }}
 OVEHOSTED_NETWORK/bridgeName=str:ovirtmgmt
 OVEHOSTED_NETWORK/bridgeIf=str:{{ interface_name }}
 OVEHOSTED_NETWORK/gateway=str:{{ gateway }}
-{% if he_force_ip4 is defined %}
-OVEHOSTED_NETWORK/forceIPv4=bool:True
-{% endif %}
-{% if he_force_ip6 is defined %}
-OVEHOSTED_NETWORK/forceIPv6=bool:True
-{% endif %}
 OVEHOSTED_ENGINE/insecureSSL=none:None
 OVEHOSTED_ENGINE/clusterName=str:{{ cluster_name }}
 OVEHOSTED_ENGINE/datacenterName=str:{{ dc_name }}


### PR DESCRIPTION
Reverts fusor/ansible-ovirt#68
I want to implement it as a parameter in the deploy command 
as they implement it the ovirt-hosted-engine-setup
https://gerrit.ovirt.org/#/c/97740/3/src/bin/hosted-engine.in