### PR TITLE
force ipv4 or ipv6 in case of dual stack environment

### DIFF
--- a/roles/self_hosted_first_host/defaults/main.yml
+++ b/roles/self_hosted_first_host/defaults/main.yml
@@ -40,6 +40,11 @@ engine_vm_static_net_netmask: '{{ ansible_default_ipv4.netmask }}'
 engine_vm_static_net_broadcast: '{{ ansible_default_ipv4.broadcast }}'
 engine_vm_static_net_gateway: '{{ ansible_default_ipv4.gateway }}'
 
+# in case of dual stack environment we can force ONE of the below keys
+# relevant for compatibility_version >= 4.3
+he_force_ip4: false
+he_force_ip6: false
+
 engine_mac_address: '00:11:22:33:44:55'
 cpu_model: model_Nehalem
 root_password: changeme

--- a/roles/self_hosted_first_host/tasks/main.yml
+++ b/roles/self_hosted_first_host/tasks/main.yml
@@ -149,7 +149,7 @@
     - install
 
 - name: Execute hosted-engine setup for version >= 4.3
-  shell: "hosted-engine --deploy --config-append={{ config_dir }}/answers"
+  shell: "hosted-engine --deploy {{ '--4' if he_force_ip4 else '--6' if he_force_ip6 else '' }} --config-append={{ config_dir }}/answers"
   when: installed.rc > 0 and compatibility_version >= 4.3
   tags:
     - install


### PR DESCRIPTION
implement it in the deploy command as they implement it in:
https://gerrit.ovirt.org/#/c/97740/3/src/bin/hosted-engine.in

you can see also the related bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1676928